### PR TITLE
[FIX] Fixed Exploration data directory case sensitivity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -252,8 +252,8 @@ The `config.json` was updated in this version:
 
 * **Persistent Map:** Added the core functionality to save explored map areas. Fog of war no longer resets between sessions.
 * **Custom View Range:** Players (or admins) can now define the size of the exploration circle.
-* **Data Storage:** Implemented a file saving system. Map data is stored in `mods/bettermap/data/"worldname"/"userId"`.
-* **Configuration:** Added `config.json` support located in `mods/bettermap/`.
+* **Data Storage:** Implemented a file saving system. Map data is stored in `mods/BetterMap/data/"worldname"/"userId"`.
+* **Configuration:** Added `config.json` support located in `mods/BetterMap/`.
 
 **Commands**
 

--- a/README.md
+++ b/README.md
@@ -134,7 +134,7 @@ All plugin files are located within the server's `mods` directory.
 
 ### Configuration File
 
-You can modify the plugin settings in `mods/bettermap/config.json`.
+You can modify the plugin settings in `mods/BetterMap/config.json`.
 
 _Note: Changing `mapQuality` or `maxChunksToLoad` requires a server restart to take effect._
 
@@ -171,7 +171,9 @@ _Note: Changing `mapQuality` or `maxChunksToLoad` requires a server restart to t
 
 ### Saved Exploration Data
 
-Map data is saved per world. You can find the saved exploration files here: `mods/bettermap/data/`
+Map data is saved per world. You can find the saved exploration files here: `mods/BetterMap/data/`
+
+> **⚠️ Note for Steam Deck/Linux/Mac Users:** If upgrading from a version prior to 1.2.7, you may need to manually rename the `Data` directory to `data` (lowercase) due to case-sensitive file systems that might be used. Move any existing files from `mods/BetterMap/Data/` to `mods/BetterMap/data/` to preserve your exploration data.
 
 ## Examples:
 

--- a/src/main/java/dev/ninesliced/configs/ExplorationPersistence.java
+++ b/src/main/java/dev/ninesliced/configs/ExplorationPersistence.java
@@ -36,7 +36,7 @@ public class ExplorationPersistence {
      */
     public ExplorationPersistence() {
         Path serverRoot = Paths.get(".").toAbsolutePath().normalize();
-        this.storageDir = serverRoot.resolve("mods").resolve("BetterMap").resolve("Data");
+        this.storageDir = serverRoot.resolve("mods").resolve("BetterMap").resolve("data");
 
         LOGGER.info("Exploration storage root directory: " + this.storageDir.toString());
         try {


### PR DESCRIPTION
Found issue on Steam Deck with case sensitive directory between Exploration persistence and Waypoint persistence, aligned both on lower case 'data' directory name to resolve this. Added note to README for Linux users to fix forward. 