### PR TITLE
Fix|NullPointerException-in-PlayerRadarProvider.update()

### DIFF
--- a/src/main/java/dev/ninesliced/providers/PlayerRadarProvider.java
+++ b/src/main/java/dev/ninesliced/providers/PlayerRadarProvider.java
@@ -49,11 +49,13 @@ public class PlayerRadarProvider implements WorldMapManager.MarkerProvider {
                 return;
             }
 
-            if (viewerUuid != null) {
-                PlayerConfig playerConfig = PlayerConfigManager.getInstance().getPlayerConfig(viewerUuid);
-                if (playerConfig != null && playerConfig.isHidePlayersOnMap()) {
-                    return;
-                }
+            if (viewerUuid == null) {
+                return;
+            }
+
+            PlayerConfig playerConfig = PlayerConfigManager.getInstance().getPlayerConfig(viewerUuid);
+            if (playerConfig != null && playerConfig.isHidePlayersOnMap()) {
+                return;
             }
 
             List<RadarData> radarDataList = PlayerRadarManager.getInstance().getRadarData(world.getName());

--- a/src/main/java/dev/ninesliced/providers/UserMarkerContextMenuProvider.java
+++ b/src/main/java/dev/ninesliced/providers/UserMarkerContextMenuProvider.java
@@ -78,15 +78,18 @@ public class UserMarkerContextMenuProvider implements WorldMapManager.MarkerProv
         if (!hidePersonalWaypoints) {
             PlayerWorldData perWorldData = player.getPlayerConfigData().getPerWorldData(world.getName());
             if (perWorldData != null) {
-                for (UserMapMarker marker : perWorldData.getUserMapMarkers()) {
-                    collector.add(buildMarkerWithContextMenu(marker, showTeleport));
+                Iterable<? extends UserMapMarker> userMapMarkers = perWorldData.getUserMapMarkers();
+                if (userMapMarkers != null) {
+                    for (UserMapMarker marker : userMapMarkers) {
+                        collector.add(buildMarkerWithContextMenu(marker, showTeleport));
+                    }
                 }
             }
         }
         
         if (!hideGlobalWaypoints) {
             WorldMarkersResource worldMarkersResource = world.getChunkStore().getStore().getResource(WorldMarkersResource.getResourceType());
-            if (worldMarkersResource != null) {
+            if (worldMarkersResource != null && worldMarkersResource.getUserMapMarkers() != null) {
                 for (UserMapMarker marker : worldMarkersResource.getUserMapMarkers()) {
                     collector.add(buildMarkerWithContextMenu(marker, showTeleport));
                 }

--- a/src/main/java/dev/ninesliced/providers/UserMarkerContextMenuProvider.java
+++ b/src/main/java/dev/ninesliced/providers/UserMarkerContextMenuProvider.java
@@ -77,15 +77,19 @@ public class UserMarkerContextMenuProvider implements WorldMapManager.MarkerProv
 
         if (!hidePersonalWaypoints) {
             PlayerWorldData perWorldData = player.getPlayerConfigData().getPerWorldData(world.getName());
-            for (UserMapMarker marker : perWorldData.getUserMapMarkers()) {
-                collector.add(buildMarkerWithContextMenu(marker, showTeleport));
+            if (perWorldData != null) {
+                for (UserMapMarker marker : perWorldData.getUserMapMarkers()) {
+                    collector.add(buildMarkerWithContextMenu(marker, showTeleport));
+                }
             }
         }
         
         if (!hideGlobalWaypoints) {
             WorldMarkersResource worldMarkersResource = world.getChunkStore().getStore().getResource(WorldMarkersResource.getResourceType());
-            for (UserMapMarker marker : worldMarkersResource.getUserMapMarkers()) {
-                collector.add(buildMarkerWithContextMenu(marker, showTeleport));
+            if (worldMarkersResource != null) {
+                for (UserMapMarker marker : worldMarkersResource.getUserMapMarkers()) {
+                    collector.add(buildMarkerWithContextMenu(marker, showTeleport));
+                }
             }
         }
     }


### PR DESCRIPTION
Problem

Two NullPointerException crash paths existed in UserMarkerContextMenuProvider.update() during marker rendering:

    getPerWorldData() could return null (e.g. player has no saved world data yet), and the result was immediately dereferenced in a for-each loop.
    getResource() could return null (e.g. chunk store not yet initialized), and was similarly used without a guard.
    In both cases, getUserMapMarkers() itself could also return null, which was not guarded against.

Any of these conditions would crash the map update for that player, potentially affecting all players in the world.
Changes

    Added a null check for perWorldData before iterating personal waypoint markers.
    Added a null check for the getUserMapMarkers() return value on both the personal and global waypoints paths.
    Added a null check for worldMarkersResource before iterating global waypoint markers.
    Updated class-level and method-level Javadoc to accurately reflect that both Edit and Teleport context menu items are added (not just Edit).
