### PR TITLE
Fix world-map zoom-out jump via configurable mapFramingRadius

### DIFF
--- a/src/main/java/dev/ninesliced/configs/ModConfig.java
+++ b/src/main/java/dev/ninesliced/configs/ModConfig.java
@@ -42,6 +42,14 @@ public class ModConfig {
     private String locationHudPosition = "top_right";
     private boolean shareAllExploration = false;
     private int maxChunksToLoad = 10000;
+    /**
+     * Max distance (in map-chunks) the explored-area framing corners may sit from the player.
+     * Bounds how far the world map can frame out and guarantees the player is always inside the
+     * framed rectangle, preventing the zoom-out "jump to a distant explored corner / won't pan back"
+     * bug caused by an unbounded explored bounding box. Set &lt;= 0 to restore the legacy
+     * (unbounded) framing behavior.
+     */
+    private int mapFramingRadius = 128;
     private boolean radarEnabled = true;
     private int radarRange = -1;
     private boolean hidePlayersOnMap = false;
@@ -215,6 +223,12 @@ public class ModConfig {
                         this.maxChunksToLoad = this.mapQuality.maxChunks;
                         needsSave = true;
                         LOGGER.warning("maxChunksToLoad exceeded limit for " + this.mapQuality + " quality. Clamped to " + this.maxChunksToLoad);
+                    }
+
+                    if (jsonObject.has("mapFramingRadius")) {
+                        this.mapFramingRadius = loaded.mapFramingRadius;
+                    } else {
+                        needsSave = true;
                     }
 
                     if (jsonObject.has("radarEnabled")) {
@@ -771,6 +785,18 @@ public class ModConfig {
     }
 
     /**
+     * Gets the explored-area framing radius (in map-chunks). The four bounding-box framing corners
+     * sent to the client world map are clamped to within this distance of the player, and the
+     * framing rectangle is forced to contain the player. A value &lt;= 0 disables clamping (legacy
+     * unbounded behavior).
+     *
+     * @return The map framing radius in map-chunks.
+     */
+    public int getMapFramingRadius() {
+        return mapFramingRadius;
+    }
+
+    /**
      * Sets the max chunks to load and saves config.
      *
      * @param maxChunksToLoad The new max chunks limit.
@@ -1181,6 +1207,7 @@ public class ModConfig {
         this.locationHudPosition = defaults.locationHudPosition;
         this.shareAllExploration = defaults.shareAllExploration;
         this.maxChunksToLoad = defaults.maxChunksToLoad;
+        this.mapFramingRadius = defaults.mapFramingRadius;
         this.radarEnabled = defaults.radarEnabled;
         this.radarRange = defaults.radarRange;
         this.hidePlayersOnMap = defaults.hidePlayersOnMap;

--- a/src/main/java/dev/ninesliced/utils/WorldMapHook.java
+++ b/src/main/java/dev/ninesliced/utils/WorldMapHook.java
@@ -1738,11 +1738,29 @@ public class WorldMapHook {
                     MapExpansionManager.MapBoundaries bounds = data.getMapExpansion().getCurrentBoundaries();
                     Set<Long> boundaryChunks = new HashSet<>(4);
 
+                    int framingRadius = ModConfig.getInstance().getMapFramingRadius();
+
                     if (bounds.minX != Integer.MAX_VALUE) {
-                        boundaryChunks.add(com.hypixel.hytale.math.util.ChunkUtil.indexChunk(bounds.minX >> 1, bounds.minZ >> 1));
-                        boundaryChunks.add(com.hypixel.hytale.math.util.ChunkUtil.indexChunk(bounds.maxX >> 1, bounds.minZ >> 1));
-                        boundaryChunks.add(com.hypixel.hytale.math.util.ChunkUtil.indexChunk(bounds.minX >> 1, bounds.maxZ >> 1));
-                        boundaryChunks.add(com.hypixel.hytale.math.util.ChunkUtil.indexChunk(bounds.maxX >> 1, bounds.maxZ >> 1));
+                        int cornerMinX = bounds.minX >> 1;
+                        int cornerMaxX = bounds.maxX >> 1;
+                        int cornerMinZ = bounds.minZ >> 1;
+                        int cornerMaxZ = bounds.maxZ >> 1;
+
+                        // Clamp the explored-area framing corners to within framingRadius map-chunks of
+                        // the player, and force the rectangle to contain the player. Without this, a far
+                        // explored point keeps a corner hundreds of chunks away, so the client frames the
+                        // whole rectangle and centres far from the player on zoom-out (the zoom-jump bug).
+                        if (framingRadius > 0) {
+                            cornerMinX = Math.max(cx - framingRadius, Math.min(cx, cornerMinX));
+                            cornerMaxX = Math.min(cx + framingRadius, Math.max(cx, cornerMaxX));
+                            cornerMinZ = Math.max(cz - framingRadius, Math.min(cz, cornerMinZ));
+                            cornerMaxZ = Math.min(cz + framingRadius, Math.max(cz, cornerMaxZ));
+                        }
+
+                        boundaryChunks.add(com.hypixel.hytale.math.util.ChunkUtil.indexChunk(cornerMinX, cornerMinZ));
+                        boundaryChunks.add(com.hypixel.hytale.math.util.ChunkUtil.indexChunk(cornerMaxX, cornerMinZ));
+                        boundaryChunks.add(com.hypixel.hytale.math.util.ChunkUtil.indexChunk(cornerMinX, cornerMaxZ));
+                        boundaryChunks.add(com.hypixel.hytale.math.util.ChunkUtil.indexChunk(cornerMaxX, cornerMaxZ));
                     }
 
                     boolean boundaryChunksChanged = cachedBoundaryChunks == null ||
@@ -1757,11 +1775,24 @@ public class WorldMapHook {
                     
                     if (needsResort) {
                         rankedChunks = new ArrayList<>(mapChunksSet.size());
-                        
+
                         for (Long chunk : mapChunksSet) {
-                            if (!boundaryChunks.contains(chunk)) {
-                                rankedChunks.add(chunk);
+                            if (boundaryChunks.contains(chunk)) {
+                                continue;
                             }
+                            // Bound the streamed chunks to a square of radius framingRadius around the
+                            // player. This keeps the client's loaded map extent centred on the player so
+                            // zoom-out frames the area around them instead of the whole explored region
+                            // (which spans back to spawn and made the view jump and refuse to pan back).
+                            // Far explored chunks are not lost — they re-stream when the player nears them.
+                            if (framingRadius > 0) {
+                                int mx = com.hypixel.hytale.math.util.ChunkUtil.xOfChunkIndex(chunk);
+                                int mz = com.hypixel.hytale.math.util.ChunkUtil.zOfChunkIndex(chunk);
+                                if (Math.abs(mx - cx) > framingRadius || Math.abs(mz - cz) > framingRadius) {
+                                    continue;
+                                }
+                            }
+                            rankedChunks.add(chunk);
                         }
 
                         final int sortCenterX = cx;


### PR DESCRIPTION
## Problem

On the in-game world map, zooming out then back in can jump to a different
location and refuse to pan back. It reproduces reliably for players who have
explored far from spawn.

**Root cause** (confirmed by instrumentation, not assumption): the map tracker
streams the player's *entire* explored region to the client (all persisted
chunks, up to `maxChunksToLoad`). The native Hytale client map auto-frames to
the extent of the chunks it holds, so for a far-roaming player the loaded set
spans from their remote base back to spawn and the client centres on the
**middle** of that huge rectangle — far from the player — on zoom-out, then
re-anchors there on zoom-in.

Measured on a player standing at chunk `-456,113` (base ~14,500 blocks from
spawn):

| | loaded chunks | loaded extent | span |
|---|---|---|---|
| before | 933 | x `-467..181`, z `-675..120` | 648 × 795 (player in a corner) |
| after  | 202 | x `-464..-448`, z `105..120` | 16 × 15 (centred on player) |

An earlier attempt that only clamped the four synthetic bounding-box *corners*
did **not** fix it — the corners are not what the client frames to; the bulk
**ranked chunk set** is.

## Fix

New `ModConfig.mapFramingRadius` (in map-chunks, default **128**; `<= 0`
restores the previous unbounded behavior — fully backward compatible). In
`WorldMapHook.RestrictedSpiralIterator`:

1. When building `rankedChunks`, skip any chunk farther than `mapFramingRadius`
   (Chebyshev distance) from the player. This bounds the actual streamed/loaded
   set so the client map stays centred on the player.
2. Clamp the four bounding-box framing corners to the same radius and force the
   rectangle to contain the player.

Far-explored chunks are not lost — they re-stream as the player approaches, and
out-of-range chunks unload normally.

## Testing

Built against the Server API and run on a live 0.5.4 server. The reporting
player confirmed the zoom-out jump is gone and the map stays centred while
panning. Tunable live via config + `/bettermap reload`.
